### PR TITLE
Added a reference page 

### DIFF
--- a/docs/about.markdown
+++ b/docs/about.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: About Us
-nav_order: 100
+nav_order: 60
 has_children: false
 show_contribute_dataset_button: true
 ---

--- a/docs/index.markdown
+++ b/docs/index.markdown
@@ -37,6 +37,7 @@ Ready to contribute a dataset? To get started, first review our [requirements]({
 
 ## More Information
 
+* [References]({{site.baseurl}}/references): What others are saying about trusted, open data.
 * [About Us]({{site.baseurl}}/about): More about the AI Alliance and this document.
 * [The AI Alliance](https://thealliance.ai){:target="ai-alliance"}
 

--- a/docs/references.markdown
+++ b/docs/references.markdown
@@ -1,0 +1,22 @@
+---
+layout: default
+title: References
+nav_order: 50
+has_children: false
+show_contribute_dataset_button: true
+---
+
+# References: What Others Are Saying About Trusted, Open Data
+
+Here is an evolving list of writings from other sources about the importance of open, trusted data. Note that the opinions expressed do not necessarily reflect the views of the AI Alliance.
+
+> **Help Wanted:** If you have other references you like, please let us know through email, [data@thealliance.ai](mailto:data@thealliance.ai), or [edit this page](https://github.com/The-AI-Alliance/open-trusted-data-initiative/blob/latest/docs/references.markdown){:target='repo'}!
+
+## The European Union AI Act - Data Implications
+
+The [The European AI Office](https://digital-strategy.ec.europa.eu/en/policies/ai-office){:target="ai-office"} of the European Union has responsibility for implementing the [AI Act](https://digital-strategy.ec.europa.eu/en/policies/regulatory-framework-ai){:target="ai-act"}, which &ldquo;... is the first-ever legal framework on AI, which addresses the risks of AI and positions Europe to play a leading role globally.&rdquo;
+
+[Open Future](https://openfuture.eu/){:target="open-future"}, in collaboration with the [Mozilla Foundation](https://foundation.mozilla.org/en/?gad_source=1){:target="mozilla"}, has authored a [white paper](https://openfuture.eu/publication/towards-robust-training-data-transparency/){:target="open-future-paper"} called _Suffiently Detailed? A proposal for implementing the AI Act’s training data transparency requirement for GPAI_ (general-purpose AI). This paper discusses new requirement for model developers to produce a _sufficiently detailed summary_ of the content used for model training. [The announcement](https://openfuture.eu/publication/towards-robust-training-data-transparency/){:target="open-future-paper"} says the following:
+
+> The purpose of the paper we are sharing today is twofold. It clarifies the categories of rights and legitimate interests that justify access to information about training data. In addition to copyright, these include, among others, privacy and personal data protection, scientific freedom, the prohibition of discrimination, and respect for cultural and linguistic diversity. Moreover, it provides a blueprint for the forthcoming template for the &ldquo;sufficiently detailed summary,&rdquo; which is intended to serve these interests while respecting the rights of all parties concerned.
+


### PR DESCRIPTION
I thought it would be useful to provide some links to content others are producing about trusted, open data, including regulatory requirements. Currently, there is just one entry for a whitepaper on the EU's AI Act requirements for model-training data.