### PR TITLE
Changed to make it clearer that the datasets come from the Wikimedia …

### DIFF
--- a/docs/catalog/contributors.markdown
+++ b/docs/catalog/contributors.markdown
@@ -133,7 +133,7 @@ Data and code are publicly available under a Creative Commons license (CC-BY-NC-
 
 ## Wikimedia Enterprise
 
-Datasets from the organization that hosts and supports Wikipedia, Wikidata, and many projects affiliated with the movement. 
+Datasets from the Wikimedia Foundation, the organization that hosts and supports Wikipedia, Wikidata, and many other projects affiliated with the movement. 
 
 * Wikimedia Enterprise [website](https://enterprise.wikimedia.com/){:target="wikimedia"}
 * Wikimedia Enterprise [Hugging Face organization](https://huggingface.co/wikimedia){:target="wikimedia-hf"}.


### PR DESCRIPTION
…Foundation.

Click the `Preview` tab and select a PR template:

- [Docs/Website only change](?expand=1&template=docs_website_pr.md&assignees=deanwampler&title=Docs&labels=documentation)
- [Other change](?expand=1&template=general_code_pr.md&assignees=deanwampler)

[//]: # (Dumb that we have to do this hack, see https://github.com/orgs/community/discussions/4620 for progress on github fixing this)
