### PR TITLE
Closes #190 - [Task/Feature/Issue] OTDI Scoring / Search - Schema

### DIFF
--- a/src/src/analytics/otdi_scoring.sql
+++ b/src/src/analytics/otdi_scoring.sql
@@ -1,0 +1,47 @@
+
+/* Table runs on top of the .csv output produced by the OTDI scoring job */
+/* This is intended to be searched using AWS Athena and presented using
+   the OTDI catalog */
+
+DROP TABLE IF EXISTS aialliance.otdi;
+
+CREATE EXTERNAL TABLE IF NOT EXISTS aialliance.otdi(
+	dataset	string,
+	datacard_date string,	
+	dataset_size double,	
+	yaml_section_count int,	
+	markdown_section_count int,
+	score float,
+	score_date string,	
+	license string,	
+	license_name string,	
+	license_link string,	
+	extra_gated_fields string,	
+	task_categories string,	
+	source_datasets	string,
+	pretty_name	string,
+	language_details string,	
+	row_license boolean, 
+	metadata_fields	string,
+	features string,
+	notes string
+)
+partitioned by (`date` date)
+ROW FORMAT SERDE 'org.apache.hadoop.hive.serde2.OpenCSVSerde'
+WITH SERDEPROPERTIES (
+   'separatorChar' = ',',
+   'quoteChar' = '"',
+   'escapeChar' = '\\'
+   )
+STORED AS TEXTFILE
+LOCATION "s3://<s3-bucket>/service=huggingface/datasets=otdi/"
+TBLPROPERTIES (
+  "skip.header.line.count"="1"
+  )
+
+/* drop view */
+drop view aialliance.v_otdi
+
+/* Create view with latest data */
+create view aialliance.v_otdi as
+    select * from aialliance.otdi where date in (select max(date) from aialliance.otdi)  


### PR DESCRIPTION
# PR Template: New Function or Feature

## Description of Changes
Pull request consists of a single SQL file that creates a schema on top of the output of the OTDI scoring job. The OTDI scoring job outputs csv data to S3. This schema allows it to be queryable using SQL and AWS Athena. AWS Athena is used to power the searchable OTDI catalog.

## Related Issues
#190 - [Task/Feature/Issue] OTDI Scoring / Search - Schema

## Testing Performed
Schema deployed without issue to the OTDI database. Currently working with AWS Athena

## Code Changes
One SQL file added to the analytics directory. The analytics directory should probably be renamed at some point in the future. File creates a table that covers all output, and a view that returns only the data from the latest run.

## Example Usage

-- Get a count of the number of datasets in the latest job run:
`select count(*) from aialliance.v_otdi`  -- 435,719 datasets

## Checklist
Confirm that the following have been completed:

* [ ] All new functions have been documented in the `docs/` directory
* [ ] Unit tests have been added for new functions
* [X] Code follows the existing style and convention
* [X] API keys or sensitive information have been removed
* [ ] (Optional) I have suggested one or more reviewers (e.g., @deanwampler, @jolson-ibm)


## Additional Context
Any additional context or information that might be helpful for reviewers:

* Relevant discussions or meetings
* Open questions or areas for further discussion  
