### PR TITLE
Closes #201 - Fixes to the (just fixed) datasets job

### DIFF
--- a/src/src/huggingface_datasets/ddl/create_table.ddl
+++ b/src/src/huggingface_datasets/ddl/create_table.ddl
@@ -68,3 +68,10 @@ TBLPROPERTIES (
 
 create or replace view <database>.v_datasets as
 select * from  <database>.datasets_complete
+
+create or replace view <database>.v_modified_datasets as 
+select * from <database>.datasets where (dataset, last_modified, request_time) in
+	(select dataset, max(last_modified) as last_modified, max(request_time) as request_time from 
+		(select * from <database>.datasets where date(last_modified)>(current_date - interval '3' day))
+	 group by dataset) 
+and date(last_modified)>(current_date - interval '3' day)

--- a/src/src/huggingface_datasets/src/get_hf_datasets.py
+++ b/src/src/huggingface_datasets/src/get_hf_datasets.py
@@ -18,7 +18,7 @@ import time
 def merge_query(date: str):
     return_val = f""" 
 merge into {os.environ["ATHENA_DATABASE_NAME"]}.datasets_complete as target
-using (select * from {os.environ["ATHENA_DATABASE_NAME"]}.datasets where date = cast('{date}' as date) and date(last_modified)>(cast('{date}' as date) - interval '3' day)) as source
+using {os.environ["ATHENA_DATABASE_NAME"]}.v_modified_datasets as source
 on target.dataset=source.dataset
 when matched then
     update set


### PR DESCRIPTION
# PR Template: New Function or Feature

## Description of Changes
See #201 for full explanation.

TL;DR: Duplicate records in the upsert may result in multiple INSERTs, rather than a single INSERT followed by UPDATES. This was unexpected, but the fix is to reduce the duplicates to a single unique record (which is the latest)

## Related Issues
None

## Testing Performed
Tested manually, cleaned up the corrupt data caused by this problem. Fix deployed to AWS Fargate and should kick in tonight a 0000 UTC. Will monitor.

## Code Changes
Duplicate records in the upsert eliminated in new view, job modified to use new view

## Example Usage
N/A

## Checklist
Confirm that the following have been completed:

* [ ] All new functions have been documented in the `docs/` directory
* [ ] Unit tests have been added for new functions
* [X] Code follows the existing style and convention
* [X] API keys or sensitive information have been removed
* [X] (Optional) I have suggested one or more reviewers (e.g., @deanwampler, @jolson-ibm)


## Additional Context
Shame on me for not catching this. Paid for it by working Saturday....
