### PR TITLE
User can now specify download file names for the dynamic tables.

### DIFF
--- a/docs/_includes/data-table-template.html
+++ b/docs/_includes/data-table-template.html
@@ -20,7 +20,7 @@
 </blockquote>
 <div id="{{ unique_id }}-filter-div">
   <form>
-    <select id="{{ unique_id }}-filter-field" type="select">
+    Filter: <select id="{{ unique_id }}-filter-field" type="select">
       <option value="name" selected="selected">Name</option>
       {% if other_keywords.size > 0 %}
       <option value="keyword">Keyword</option>
@@ -38,9 +38,13 @@
       <option value="!=">!=</option>
     </select>
     <input id="{{ unique_id }}-filter-value" type="text" placeholder="value to filter" form="none">
-    <button id="{{ unique_id }}-filter-clear" type="reset" value="reset">Clear Filter</button>
     <span id="{{ unique_id }}-num-rows"></span>
-    <button id="{{ unique_id }}-download-data" type="button" onclick="saveTableAsJSON('{{ unique_id }}', '{{ unique_id }}-download-message');">Download Table</button><br/> <!-- <br/> makes it wrap, but with less vertical space than using <p>...</p>. -->
+    <br/>
+    Save to: <input id="{{ unique_id }}-file-name" type="text" class="width-50" value="{{ unique_id }}.json" form="none">    
+    <button id="{{ unique_id }}-download-data" type="button" onclick="saveTableAsJSON('{{ unique_id }}', '{{ unique_id }}-download-message');">Download Table</button>
+    <span class="width-100">&nbsp;</span>
+    <button id="{{ unique_id }}-filter-clear" type="reset" value="reset">Reset</button>
+    <br/> <!-- <br/> makes it wrap, but with less vertical space than using <p>...</p>. -->
     <span id="{{ unique_id }}-download-message"></span>
   </form>
 </div>

--- a/docs/_includes/js/custom.js
+++ b/docs/_includes/js/custom.js
@@ -200,12 +200,19 @@ function saveTableAsJSON(id_prefix, id_message) {
   if (! table) {
     console.log(`ERROR: No table for id ${id_prefix}!`);
   } else {
-    allData = table.getData();
-    filteredData = table.getData("active");
-    filteredStr = allData.length != filteredData.length ? "_filtered" : "";
-    filteredMsg = allData.length != filteredData.length ? "filtered" : "all";
-    fileName = `${id_prefix}${filteredStr}.json`;
-    message = `<span>Writing ${filteredMsg} data to <code>${fileName}</code> in your downloads folder.</span>`;
+    let allData = table.getData();
+    let filteredData = table.getData("active");
+    let fileNameElem = document.getElementById(`${id_prefix}-file-name`);
+    var fileName = fileNameElem.value;
+    if (fileName) {
+      if (! fileName.endsWith(".json")) {
+        fileName = `${fileName}.json`;
+      }
+    } else {
+      let filteredStr = allData.length != filteredData.length ? "_filtered" : "";
+      fileName = `${id_prefix}${filteredStr}.json`;
+    }
+    message = `<span>Writing table to <code>${fileName}</code> in your downloads folder.</span>`;
     setDownloadMessage(id_prefix, message);
     setInnerHTML(id_message, message);
     saveJSON(filteredData, fileName);
@@ -293,10 +300,11 @@ function setNumRows(id_prefix, table, num = -1) {
 function enableTableFilters(id_prefix, table) {
 
   // Define variables for input elements
-  var fieldElem = document.getElementById(`${id_prefix}-filter-field`);
-  var typeElem  = document.getElementById(`${id_prefix}-filter-type`);
-  var valueElem = document.getElementById(`${id_prefix}-filter-value`);
-  var clearElem = document.getElementById(`${id_prefix}-filter-clear`);
+  var fieldElem    = document.getElementById(`${id_prefix}-filter-field`);
+  var typeElem     = document.getElementById(`${id_prefix}-filter-type`);
+  var valueElem    = document.getElementById(`${id_prefix}-filter-value`);
+  var clearElem    = document.getElementById(`${id_prefix}-filter-clear`);
+  var fileNameElem = document.getElementById(`${id_prefix}-file-name`);
 
   // Trigger setFilter function with correct parameters
   function updateFilter(){
@@ -317,6 +325,7 @@ function enableTableFilters(id_prefix, table) {
     fieldElem.value = "";
     typeElem.value = "like";
     valueElem.value = "";
+    fileNameElem.value = `${id_prefix}.json`;
     table.clearFilter()
     setNumRows(id_prefix, table);
     setDownloadMessage(id_prefix, "");

--- a/docs/_includes/specification-table-template.html
+++ b/docs/_includes/specification-table-template.html
@@ -10,7 +10,7 @@
 </blockquote>
 <div id="{{ include.table_id }}-filter-div">
   <form>
-    <select id="{{ include.table_id }}-filter-field" type="select">
+    Filter: <select id="{{ include.table_id }}-filter-field" type="select">
       <option value="field_name" selected="selected">Field Name</option>
       <!-- TODO: Since we encode the required value using integers, we need a way to make the
       filtering intuitive,e.g., by dynamically changing the ...-filter-type options to match
@@ -29,9 +29,13 @@
       <option value="!=">!=</option>
     </select>
     <input id="{{ include.table_id }}-filter-value" type="text" placeholder="value to filter" form="none">
-    <button id="{{ include.table_id }}-filter-clear" type="reset" value="reset">Clear Filter</button>
     <span id="{{ include.table_id }}-num-rows"></span>
-    <button id="{{ include.table_id }}-download-data" type="button" onclick="saveTableAsJSON('{{ include.table_id }}', '{{ include.table_id }}-download-message');">Download Table</button><br/> <!-- <br/> makes it wrap, but with less vertical space than using <p>...</p>. -->
+    <br/>
+    Save to: <input id="{{ include.table_id }}-file-name" type="text" class="width-50" value="{{ include.table_id }}.json" form="none">    
+    <button id="{{ include.table_id }}-download-data" type="button" onclick="saveTableAsJSON('{{ include.table_id }}', '{{ include.table_id }}-download-message');">Download</button>
+    <span class="width-100">&nbsp;</span>
+    <button id="{{ include.table_id }}-filter-clear" type="reset" value="reset">Reset</button>
+    <br/> <!-- <br/> makes it wrap, but with less vertical space than using <p>...</p>. -->
     <span id="{{ include.table_id }}-download-message"></span>
   </form>
 </div>

--- a/docs/_sass/custom/custom.scss
+++ b/docs/_sass/custom/custom.scss
@@ -59,6 +59,15 @@ td.project-title {
   font-size: 110% !important;
 }
 
+.width-25 {
+  width: 25% !important;
+}
+.width-50 {
+  width: 50% !important;
+}
+.width-75 {
+  width: 75% !important;
+}
 .width-100 {
   width: 100% !important;
 }


### PR DESCRIPTION
Fix for #161; allow user to specify a file name when downloading JSON data from the dynamic tables.

## Description of Changes
In the filter forms for each table, I added a file name field with a default value and modified the JS code to use it or construct the default value, if the field is empty.

It doesn't "prompt" for a value, per se, just lets the user edit the field before saving. The file will still be downloaded to the user's _downloads_ folder. No mechanism is provided to change the path.

## Related Issues

#161 
